### PR TITLE
chore: fix bug when primevue component is used as service

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -16,8 +16,8 @@ function registerItems(items: any[] = [], options: ConstructsType = {}, params: 
 
   return items.filter((item) => {
     const name = item?.name;
-    const matchedIn = included === '*' || included === undefined ? true : Utils.object.isNotEmpty(included) ? included.some((inc: string) => name?.toLowerCase() === inc.toLowerCase()) : false;
-    const matchedEx = included === '*' ? false : excluded === '*' ? true : Utils.object.isNotEmpty(excluded) ? excluded.some((exc: string) => name?.toLowerCase() === exc.toLowerCase()) : false;
+    const matchedIn = included === '*' || included === undefined ? true : Utils.object.isNotEmpty(included) ? included.some((inc) => name?.toLowerCase() === Utils.object.isString(inc) ? inc?.toLowerCase() : inc?.name?.toLowerCase()) : false;
+    const matchedEx = included === '*' ? false : excluded === '*' ? true : Utils.object.isNotEmpty(excluded) ? excluded.some((exc: string) => name?.toLowerCase() === Utils.object.isString(exc) ? exc?.toLowerCase() : exc?.name?.toLowerCase()) : false;
 
     return matchedIn && !matchedEx;
   });


### PR DESCRIPTION
reproduction:
```ts
primevue: {
   components: {
      include: ['Dialog', { name: 'Toast', use: { as: 'ToastService' } }]
   }
}
```