### PR TITLE
fix: only include all components if no specific excludes

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -18,7 +18,7 @@ function registerItems(items: any[] = [], options: ConstructsType = {}, params: 
   return items.filter((item) => {
     const name = item?.name;
     const matchedIn = included === '*' || included === undefined ? true : Utils.object.isNotEmpty(included) ? included.some((inc: any) => isMatched(name, inc)) : false;
-    const matchedEx = included === '*' ? false : excluded === '*' ? true : Utils.object.isNotEmpty(excluded) ? excluded.some((exc: any) => isMatched(name, exc)) : false;
+    const matchedEx = (included === '*' && excluded === '*') ? false : excluded === '*' ? true : Utils.object.isNotEmpty(excluded) ? excluded.some((exc: any) => isMatched(name, exc)) : false;
 
     return matchedIn && !matchedEx;
   });


### PR DESCRIPTION
A suggested fix for https://github.com/primefaces/primevue-nuxt-module/issues/29.

A side effect of this change is that it assumes that if a user has included and excluded all components, including all should take priority.