### PR TITLE
fix: normalize file paths for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "nuxt-primevue",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-primevue",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.7.3",
+        "pathe": "^1.1.2",
         "primevue": "~3.48.1"
       },
       "devDependencies": {
@@ -8887,9 +8888,9 @@
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
-      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "nuxt-primevue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-primevue",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.7.3",
+        "pathe": "^1.1.2",
         "primevue": "~3.49.1"
       },
       "devDependencies": {
@@ -8887,9 +8888,9 @@
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
-      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
     },
     "node_modules/pathval": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,21 +44,22 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.7.3",
+    "pathe": "^1.1.2",
     "primevue": "~3.48.1"
   },
   "devDependencies": {
-    "@types/node": "^18.17.17",
     "@nuxt/devtools": "^0.8.5",
     "@nuxt/eslint-config": "^0.2.0",
     "@nuxt/module-builder": "^0.5.1",
     "@nuxt/schema": "^3.7.3",
     "@nuxt/test-utils": "^3.7.3",
-    "nitropack": "^2.6.3",
+    "@types/node": "^18.17.17",
     "changelogen": "^0.5.5",
     "eslint": "^8.49.0",
+    "nitropack": "^2.6.3",
     "nuxt": "^3.7.3",
-    "vitest": "^0.33.0",
-    "prettier": "2.7.1"
+    "prettier": "2.7.1",
+    "vitest": "^0.33.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,5 @@
 import { addPlugin, addPluginTemplate, addTemplate, createResolver, defineNuxtModule } from '@nuxt/kit';
+import { normalize } from 'pathe';
 import { register } from './register';
 import type { ModuleOptions } from './types';
 
@@ -80,7 +81,7 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#imports';
 ${registered.config.map((config: any) => `import ${config.as} from '${config.from}';`).join('\n')}
 ${registered.services.map((service: any) => `import ${service.as} from '${service.from}';`).join('\n')}
 ${registered.directives.map((directive: any) => `import ${directive.as} from '${directive.from}';`).join('\n')}
-${importPT ? `import ${importPT.as} from '${importPT.from}';\n` : ''}
+${importPT ? `import ${importPT.as} from '${normalize(importPT.from)}';\n` : ''}
 
 export default defineNuxtPlugin(({ vueApp }) => {
   const runtimeConfig = useRuntimeConfig();


### PR DESCRIPTION
When using `importPT` with `path.resolve` on Windows, the `\` characters are not escaped, leading to "failed to resolve import" errors.

This PR addresses this issue.

![image](https://github.com/primefaces/primevue-nuxt-module/assets/31937175/6a9b906d-1dbd-4c6e-9792-f59a653c4496)
