### PR TITLE
fix: resolve type conflict by updating `primevue`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "nuxt-primevue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-primevue",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.7.3",
-        "primevue": "~3.49.1"
+        "primevue": "~3.51.0"
       },
       "devDependencies": {
         "@nuxt/devtools": "^0.8.5",
@@ -9483,9 +9483,9 @@
       }
     },
     "node_modules/primevue": {
-      "version": "3.49.1",
-      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.49.1.tgz",
-      "integrity": "sha512-OmUTqbKbPB63Zqf7uA49cipDi+Qh+/13AYJPwgvsVsI4QmAKIkeibBwkOgj1CNIFlopfF79YmyBshFUAPqlw9A==",
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.51.0.tgz",
+      "integrity": "sha512-BdMveidLSr0fNJ5+mxuke8mMCHyiXwvfDP4iwPr6R98rl3E0Wcm1u4/RKVrL7o0Iq606SXyhPQL3LGyAfXngcA==",
       "peerDependencies": {
         "vue": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.7.3",
-    "primevue": "~3.49.1"
+    "primevue": "~3.51.0"
   },
   "devDependencies": {
     "@types/node": "^18.17.17",


### PR DESCRIPTION
This updates `primevue` to the latest version which includes https://github.com/primefaces/primevue/pull/5419 to prevent https://github.com/nuxt/nuxt/issues/26214 from happening.