### PR TITLE
fix: resolve naming conflicts 

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -2,6 +2,7 @@ import { addPlugin, addPluginTemplate, addTemplate, createResolver, defineNuxtMo
 import { normalize } from 'pathe';
 import { register } from './register';
 import type { ModuleOptions } from './types';
+import { useId } from 'nuxt/app';
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -103,10 +104,8 @@ export default defineNuxtPlugin(({ vueApp }) => {
   const runtimeConfig = useRuntimeConfig();
   const config = runtimeConfig?.public?.primevue ?? {};
   const { usePrimeVue = true, options = {} } = config;
-  const pt = ${importPT ? `{ pt: ${importPT.as} }` : `{}`};
-  const theme = ${hasTheme ? `{ theme: ${importTheme.as} }` : `{}`};
 
-  usePrimeVue && vueApp.use(PrimeVue, { ...options, ...pt, ...theme });
+  usePrimeVue && vueApp.use(PrimeVue, { ...options, ...${importPT ? `{ pt: ${importPT.as} }` : `{}`}, ...${hasTheme ? `{ theme: ${importTheme.as} }` : `{}`} });
   ${registered.services.map((service: any) => `vueApp.use(${service.as});`).join('\n')}
   ${registered.directives.map((directive: any) => `vueApp.directive('${directive.name}', ${directive.as});`).join('\n')}
 });

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,6 @@ import { addPlugin, addPluginTemplate, addTemplate, createResolver, defineNuxtMo
 import { normalize } from 'pathe';
 import { register } from './register';
 import type { ModuleOptions } from './types';
-import { useId } from 'nuxt/app';
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {


### PR DESCRIPTION
Hey 🖐. 
When i worked with on custom passthrough preset, i've noticed, when i passed those options in my nuxt.config:
```
    importTheme: { from: '@/primevue-theme/index.mjs' },
    importPT: { from: '@/primevue-theme/passthrough.mjs', as: 'pt' },
```
it's caused an error, because in your module registration you already provided that name, so it's throwing an ReferenceError, because **pt** is already declared. 
So i used the object spread to fix it.

Here is little demo of bug: https://codesandbox.io/p/github/rxMATTEO/primevue-naming-bug/main